### PR TITLE
Add related syncing and more logging improvement

### DIFF
--- a/lib/src/endpoints.dart
+++ b/lib/src/endpoints.dart
@@ -20,6 +20,11 @@ class EndpointResult<TSyncable extends SyncableMixin> {
   /// Was the endpoint operation successful?
   bool get successful =>
       response.statusCode >= 200 && response.statusCode < 300 && errors.isEmpty;
+
+  @override
+  String toString() {
+    return 'EndpointResult(response: $response, instances: $instances, errors: $errors, responseBody: ${response.body})';
+  }
 }
 
 /// Represents an entity endpoint
@@ -285,5 +290,10 @@ class RestfulApiEndpoint<TSyncable extends SyncableMixin>
     }
 
     return result;
+  }
+
+  @override
+  String toString() {
+    return 'RestfulApiEndpoint(url: $url, serializer: $serializer, client: $client, paginator: $paginator, readOnly: $readOnly, headers: $headers)';
   }
 }

--- a/lib/src/endpoints.dart
+++ b/lib/src/endpoints.dart
@@ -50,6 +50,10 @@ abstract class Endpoint<TSyncable extends SyncableMixin> {
 
   /// Pulls and returns multiple entities
   Future<EndpointResult<TSyncable>> pullAll({DateTime? since});
+
+  Future<EndpointResult<TSyncable>> pullOneByRemoteKey({
+    required String remoteKey,
+  });
 }
 
 /// Represents a restful api endpoint
@@ -255,7 +259,31 @@ class RestfulApiEndpoint<TSyncable extends SyncableMixin>
     return Uri.parse('$url${instance.getKeyRepresentation()}');
   }
 
+  Uri _uriFromRemoteKey(String remoteKey) {
+    return Uri.parse('$url$remoteKey}');
+  }
+
   String _sinceSnippet(DateTime since) {
     return 'modified__gt=${Uri.encodeComponent(since.toIso8601String())}';
+  }
+
+  @override
+  Future<EndpointResult<TSyncable>> pullOneByRemoteKey({
+    required String remoteKey,
+  }) async {
+    final response = await client.get(
+      _uriFromRemoteKey(remoteKey),
+      headers: headers,
+    );
+
+    final instance = _responseToInstance(serializer, response);
+
+    final result = EndpointResult<TSyncable>(response, []);
+
+    if (instance != null) {
+      result.instances.add(instance);
+    }
+
+    return result;
   }
 }

--- a/lib/src/endpoints.dart
+++ b/lib/src/endpoints.dart
@@ -23,7 +23,7 @@ class EndpointResult<TSyncable extends SyncableMixin> {
 
   @override
   String toString() {
-    return 'EndpointResult(response: $response, instances: $instances, errors: $errors, responseBody: ${response.body})';
+    return 'EndpointResult(instances: $instances, errors: $errors, responseBody: ${response.body}, responseCode: ${response.statusCode})';
   }
 }
 

--- a/lib/src/endpoints.dart
+++ b/lib/src/endpoints.dart
@@ -56,7 +56,7 @@ abstract class Endpoint<TSyncable extends SyncableMixin> {
   /// Pulls and returns multiple entities
   Future<EndpointResult<TSyncable>> pullAll({DateTime? since});
 
-  Future<EndpointResult<TSyncable>> pullOneByRemoteKey({
+  Future<EndpointResult<TSyncable>> pullByRemoteKey({
     required String remoteKey,
   });
 }
@@ -273,7 +273,7 @@ class RestfulApiEndpoint<TSyncable extends SyncableMixin>
   }
 
   @override
-  Future<EndpointResult<TSyncable>> pullOneByRemoteKey({
+  Future<EndpointResult<TSyncable>> pullByRemoteKey({
     required String remoteKey,
   }) async {
     final response = await client.get(

--- a/lib/src/endpoints.dart
+++ b/lib/src/endpoints.dart
@@ -260,7 +260,7 @@ class RestfulApiEndpoint<TSyncable extends SyncableMixin>
   }
 
   Uri _uriFromRemoteKey(String remoteKey) {
-    return Uri.parse('$url$remoteKey}');
+    return Uri.parse('$url$remoteKey');
   }
 
   String _sinceSnippet(DateTime since) {

--- a/lib/src/moor/moor.dart
+++ b/lib/src/moor/moor.dart
@@ -34,15 +34,3 @@ abstract class SyncableTable extends Table {
   /// The actual table
   SyncableTable actualTable();
 }
-
-class RelatedEntity {
-  final Column localKeyColumn;
-  final Column remoteKeyColumn;
-  final Endpoint endpoint;
-
-  RelatedEntity({
-    required this.localKeyColumn,
-    required this.remoteKeyColumn,
-    required this.endpoint,
-  });
-}

--- a/lib/src/moor/moor.dart
+++ b/lib/src/moor/moor.dart
@@ -34,3 +34,15 @@ abstract class SyncableTable extends Table {
   /// The actual table
   SyncableTable actualTable();
 }
+
+class RelatedEntity {
+  final Column localKeyColumn;
+  final Column remoteKeyColumn;
+  final Endpoint endpoint;
+
+  RelatedEntity({
+    required this.localKeyColumn,
+    required this.remoteKeyColumn,
+    required this.endpoint,
+  });
+}

--- a/lib/src/moor/moor_storage.dart
+++ b/lib/src/moor/moor_storage.dart
@@ -36,11 +36,11 @@ class MoorStorage<TProxy extends ProxyMixin<DataClass>>
     if (remoteKey != null) {
       instance = await (database.select(table.actualTable() as TableInfo)
             ..where((t) => table.remoteKeyColumn().equals(remoteKey)))
-          .getSingle();
+          .getSingleOrNull();
     } else if (localKey != null) {
       instance = await (database.select(table.actualTable() as TableInfo)
             ..where((t) => table.localKeyColumn().equals(localKey)))
-          .getSingle();
+          .getSingleOrNull();
     }
 
     if (instance == null) {

--- a/lib/src/moor/moor_storage.dart
+++ b/lib/src/moor/moor_storage.dart
@@ -54,7 +54,7 @@ class MoorStorage<TProxy extends ProxyMixin<DataClass>>
   Future<StorageResult<TProxy>> insert(TProxy instance,
       {dynamic remoteKey, dynamic localKey}) async {
     await database.into(table.actualTable() as TableInfo).insert(instance);
-    return StorageResult<TProxy>(true);
+    return StorageResult<TProxy>(successful: true);
   }
 
   @override
@@ -71,6 +71,6 @@ class MoorStorage<TProxy extends ProxyMixin<DataClass>>
       throw ArgumentError('Could not find a local instance');
     }
 
-    return StorageResult<TProxy>(true);
+    return StorageResult<TProxy>(successful: true);
   }
 }

--- a/lib/src/serialization.dart
+++ b/lib/src/serialization.dart
@@ -36,6 +36,11 @@ abstract class SerializableField {
   bool areEqual(dynamic a, dynamic b) {
     return a == b;
   }
+
+  @override
+  String toString() {
+    return 'SerializableField(name: $name, prefix: $prefix, source: $source)';
+  }
 }
 
 /// Represents an integer field which may be serialized
@@ -54,6 +59,11 @@ class IntegerField extends SerializableField {
   @override
   dynamic toRepresentation(value) {
     return value;
+  }
+
+  @override
+  String toString() {
+    return 'IntegerField(name: $name, prefix: $prefix, source: $source)';
   }
 }
 
@@ -79,6 +89,11 @@ class DoubleField extends SerializableField {
   dynamic toRepresentation(value) {
     return value;
   }
+
+  @override
+  String toString() {
+    return 'DoubleField(name: $name, prefix: $prefix, source: $source)';
+  }
 }
 
 /// Represents an string field which may be serialized
@@ -100,6 +115,11 @@ class StringField extends SerializableField {
   @override
   dynamic toRepresentation(value) {
     return value;
+  }
+
+  @override
+  String toString() {
+    return 'StringField(name: $name, prefix: $prefix, source: $source)';
   }
 }
 
@@ -130,6 +150,11 @@ class DateTimeField extends SerializableField {
   dynamic toRepresentation(value) {
     return (value as DateTime).toUtc().toIso8601String();
   }
+
+  @override
+  String toString() {
+    return 'DateTimeField(name: $name, prefix: $prefix, source: $source)';
+  }
 }
 
 class DateField extends SerializableField {
@@ -159,6 +184,11 @@ class DateField extends SerializableField {
   dynamic toRepresentation(value) {
     return (value as DateTime).toIso8601String().split('T')[0];
   }
+
+  @override
+  String toString() {
+    return 'DateField(name: $name, prefix: $prefix, source: $source)';
+  }
 }
 
 /// Represents a boolean field which may be serialized
@@ -182,6 +212,11 @@ class BoolField extends SerializableField {
   dynamic toRepresentation(value) {
     return json.encode(value);
   }
+
+  @override
+  String toString() {
+    return 'BoolField(name: $name, prefix: $prefix, source: $source)';
+  }
 }
 
 /// Added to a class to support serialization
@@ -200,6 +235,11 @@ class ValidationException implements Exception {
   String cause;
 
   ValidationException(this.cause);
+
+  @override
+  String toString() {
+    return 'ValidationException($cause)';
+  }
 }
 
 /// Performs serialization
@@ -342,4 +382,9 @@ abstract class Serializer<TSerializable extends SerializableMixin> {
   TSerializable createInstance(Map<String, dynamic> validatedData);
 
   Map toMap();
+
+  @override
+  String toString() {
+    return 'Serializer(data: $data, instance: $instance, prefix: $prefix)';
+  }
 }

--- a/lib/src/storage.dart
+++ b/lib/src/storage.dart
@@ -6,7 +6,12 @@ import 'sync.dart';
 class StorageResult<TSyncable extends SyncableMixin> {
   bool successful;
 
-  StorageResult(this.successful);
+  StorageResult({required this.successful});
+
+  @override
+  String toString() {
+    return 'StorageResult(successful: $successful)';
+  }
 }
 
 /// Responsible for local storage of syncable entities
@@ -21,8 +26,7 @@ abstract class Storage<TSyncable extends SyncableMixin> {
   Future<StorageResult<TSyncable>> insert(TSyncable instance);
 
   /// Upserts an instance using an optional local key
-  Future<StorageResult<TSyncable>> update(
-    TSyncable instance, {
+  Future<StorageResult<TSyncable>> update(TSyncable instance, {
     dynamic remoteKey,
     dynamic localKey,
   });
@@ -45,7 +49,11 @@ class MoorRelation<TProxy extends ProxyMixin<DataClass>>
   /// The foreign key's table
   final SyncableTable fkTable;
 
-  MoorRelation(this.database, this.fkColumn, this.fkTable);
+  MoorRelation({
+    required this.database,
+    required this.fkColumn,
+    required this.fkTable,
+  });
 
   @override
   Future<String?> needToSyncInstance(TProxy instance) async {
@@ -55,9 +63,10 @@ class MoorRelation<TProxy extends ProxyMixin<DataClass>>
     // get the related instance
     final fkInstance = await (database.select(
       fkTable.actualTable() as TableInfo,
-    )..where(
+    )
+      ..where(
             (t) => fkTable.remoteKeyColumn().equals(remoteKey),
-          ))
+      ))
         .getSingleOrNull();
 
     // if the related instance is missing then return null else return its
@@ -67,5 +76,10 @@ class MoorRelation<TProxy extends ProxyMixin<DataClass>>
     }
 
     return null;
+  }
+
+  @override
+  String toString() {
+    return 'MoorRelation(database: $database, fkColumn: $fkColumn, fkTable: $fkTable)';
   }
 }

--- a/lib/src/storage.dart
+++ b/lib/src/storage.dart
@@ -1,3 +1,6 @@
+import 'package:entity_sync/moor_sync.dart';
+import 'package:moor/moor.dart';
+
 import 'sync.dart';
 
 class StorageResult<TSyncable extends SyncableMixin> {
@@ -18,6 +21,39 @@ abstract class Storage<TSyncable extends SyncableMixin> {
   Future<StorageResult<TSyncable>> insert(TSyncable instance);
 
   /// Upserts an instance using an optional local key
-  Future<StorageResult<TSyncable>> update(TSyncable instance,
-      {dynamic remoteKey, dynamic localKey});
+  Future<StorageResult<TSyncable>> update(
+    TSyncable instance, {
+    dynamic remoteKey,
+    dynamic localKey,
+  });
+}
+
+abstract class Relation<TSyncable extends SyncableMixin> {
+  Future<String?> needToSyncInstance(TSyncable instance);
+}
+
+class MoorRelation<TProxy extends ProxyMixin<DataClass>>
+    implements Relation<TProxy> {
+  final GeneratedDatabase database;
+  final String fkColumn;
+  final SyncableTable fkTable;
+
+  MoorRelation(this.database, this.fkColumn, this.fkTable);
+
+  @override
+  Future<String?> needToSyncInstance(TProxy instance) async {
+    final remoteKey = instance.toMap()[fkColumn];
+    final fkInstance = await (database.select(
+      fkTable.actualTable() as TableInfo,
+    )..where(
+            (t) => fkTable.remoteKeyColumn().equals(remoteKey),
+          ))
+        .getSingleOrNull();
+
+    if (fkInstance == null) {
+      return remoteKey;
+    }
+
+    return null;
+  }
 }

--- a/lib/src/sync.dart
+++ b/lib/src/sync.dart
@@ -148,7 +148,7 @@ class SyncController<TSyncable extends SyncableMixin> {
           // if the related instance is missing then sync it
           if (remoteKey != null) {
             // pull down the related instance
-            final endpointResult = await relation.endpoint.pullOneByRemoteKey(
+            final endpointResult = await relation.endpoint.pullByRemoteKey(
               remoteKey: remoteKey,
             );
 

--- a/lib/src/sync.dart
+++ b/lib/src/sync.dart
@@ -100,7 +100,7 @@ class SyncController<TSyncable extends SyncableMixin> {
 
   final List<SyncControllerRelation> relations;
 
-  SyncController(this.endpoint, this.storage, this.relations);
+  SyncController(this.endpoint, this.storage, {this.relations = const []});
 
   Future<SyncResult<TSyncable>> sync([DateTime? since]) async {
     /// get all instances to sync

--- a/lib/src/sync.dart
+++ b/lib/src/sync.dart
@@ -88,6 +88,11 @@ class SyncResult<TSyncable extends SyncableMixin> {
   final EndpointResult<TSyncable> pullResults;
 
   SyncResult(this.pushResults, this.pullResults);
+
+  @override
+  String toString() {
+    return 'SyncResult(pushResults: $pushResults, pullResults: $pullResults)';
+  }
 }
 
 /// Responsible for controlling the syncing of entities
@@ -214,4 +219,9 @@ class SyncControllerRelation {
   final Storage storage;
 
   SyncControllerRelation(this.relation, this.endpoint, this.storage);
+
+  @override
+  String toString() {
+    return 'SyncControllerRelation(relation: $relation, endpoint: $endpoint, storage: $storage';
+  }
 }

--- a/test/models/database.dart
+++ b/test/models/database.dart
@@ -1,10 +1,15 @@
 import 'package:moor/moor.dart';
 
+import 'related_entities.dart';
 import 'test_entities.dart';
 
 part 'database.moor.dart';
 
-@UseMoor(tables: [TestMoorEntities])
+@UseMoor(tables: [
+  TestMoorEntities,
+  FirstRelatedEntities,
+  SecondRelatedEntities,
+])
 class TestDatabase extends _$TestDatabase {
   TestDatabase(QueryExecutor e) : super(e);
 

--- a/test/models/database.moor.dart
+++ b/test/models/database.moor.dart
@@ -317,12 +317,522 @@ class $TestMoorEntitiesTable extends TestMoorEntities
   }
 }
 
+class FirstRelatedEntity extends DataClass
+    implements Insertable<FirstRelatedEntity> {
+  /// Indicates if the entity should be synced
+  final bool shouldSync;
+  final String uuid;
+  final int id;
+  final String relatedEntity;
+  FirstRelatedEntity(
+      {required this.shouldSync,
+      required this.uuid,
+      required this.id,
+      required this.relatedEntity});
+  factory FirstRelatedEntity.fromData(
+      Map<String, dynamic> data, GeneratedDatabase db,
+      {String? prefix}) {
+    final effectivePrefix = prefix ?? '';
+    final boolType = db.typeSystem.forDartType<bool>();
+    final stringType = db.typeSystem.forDartType<String>();
+    final intType = db.typeSystem.forDartType<int>();
+    return FirstRelatedEntity(
+      shouldSync: boolType
+          .mapFromDatabaseResponse(data['${effectivePrefix}should_sync'])!,
+      uuid: stringType.mapFromDatabaseResponse(data['${effectivePrefix}uuid'])!,
+      id: intType.mapFromDatabaseResponse(data['${effectivePrefix}id'])!,
+      relatedEntity: stringType
+          .mapFromDatabaseResponse(data['${effectivePrefix}related_entity'])!,
+    );
+  }
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['should_sync'] = Variable<bool>(shouldSync);
+    map['uuid'] = Variable<String>(uuid);
+    map['id'] = Variable<int>(id);
+    map['related_entity'] = Variable<String>(relatedEntity);
+    return map;
+  }
+
+  FirstRelatedEntitiesCompanion toCompanion(bool nullToAbsent) {
+    return FirstRelatedEntitiesCompanion(
+      shouldSync: Value(shouldSync),
+      uuid: Value(uuid),
+      id: Value(id),
+      relatedEntity: Value(relatedEntity),
+    );
+  }
+
+  factory FirstRelatedEntity.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= moorRuntimeOptions.defaultSerializer;
+    return FirstRelatedEntity(
+      shouldSync: serializer.fromJson<bool>(json['shouldSync']),
+      uuid: serializer.fromJson<String>(json['uuid']),
+      id: serializer.fromJson<int>(json['id']),
+      relatedEntity: serializer.fromJson<String>(json['relatedEntity']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= moorRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'shouldSync': serializer.toJson<bool>(shouldSync),
+      'uuid': serializer.toJson<String>(uuid),
+      'id': serializer.toJson<int>(id),
+      'relatedEntity': serializer.toJson<String>(relatedEntity),
+    };
+  }
+
+  FirstRelatedEntity copyWith(
+          {bool? shouldSync, String? uuid, int? id, String? relatedEntity}) =>
+      FirstRelatedEntity(
+        shouldSync: shouldSync ?? this.shouldSync,
+        uuid: uuid ?? this.uuid,
+        id: id ?? this.id,
+        relatedEntity: relatedEntity ?? this.relatedEntity,
+      );
+  @override
+  String toString() {
+    return (StringBuffer('FirstRelatedEntity(')
+          ..write('shouldSync: $shouldSync, ')
+          ..write('uuid: $uuid, ')
+          ..write('id: $id, ')
+          ..write('relatedEntity: $relatedEntity')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => $mrjf($mrjc(shouldSync.hashCode,
+      $mrjc(uuid.hashCode, $mrjc(id.hashCode, relatedEntity.hashCode))));
+  @override
+  bool operator ==(dynamic other) =>
+      identical(this, other) ||
+      (other is FirstRelatedEntity &&
+          other.shouldSync == this.shouldSync &&
+          other.uuid == this.uuid &&
+          other.id == this.id &&
+          other.relatedEntity == this.relatedEntity);
+}
+
+class FirstRelatedEntitiesCompanion
+    extends UpdateCompanion<FirstRelatedEntity> {
+  final Value<bool> shouldSync;
+  final Value<String> uuid;
+  final Value<int> id;
+  final Value<String> relatedEntity;
+  const FirstRelatedEntitiesCompanion({
+    this.shouldSync = const Value.absent(),
+    this.uuid = const Value.absent(),
+    this.id = const Value.absent(),
+    this.relatedEntity = const Value.absent(),
+  });
+  FirstRelatedEntitiesCompanion.insert({
+    this.shouldSync = const Value.absent(),
+    required String uuid,
+    this.id = const Value.absent(),
+    required String relatedEntity,
+  })   : uuid = Value(uuid),
+        relatedEntity = Value(relatedEntity);
+  static Insertable<FirstRelatedEntity> custom({
+    Expression<bool>? shouldSync,
+    Expression<String>? uuid,
+    Expression<int>? id,
+    Expression<String>? relatedEntity,
+  }) {
+    return RawValuesInsertable({
+      if (shouldSync != null) 'should_sync': shouldSync,
+      if (uuid != null) 'uuid': uuid,
+      if (id != null) 'id': id,
+      if (relatedEntity != null) 'related_entity': relatedEntity,
+    });
+  }
+
+  FirstRelatedEntitiesCompanion copyWith(
+      {Value<bool>? shouldSync,
+      Value<String>? uuid,
+      Value<int>? id,
+      Value<String>? relatedEntity}) {
+    return FirstRelatedEntitiesCompanion(
+      shouldSync: shouldSync ?? this.shouldSync,
+      uuid: uuid ?? this.uuid,
+      id: id ?? this.id,
+      relatedEntity: relatedEntity ?? this.relatedEntity,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (shouldSync.present) {
+      map['should_sync'] = Variable<bool>(shouldSync.value);
+    }
+    if (uuid.present) {
+      map['uuid'] = Variable<String>(uuid.value);
+    }
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (relatedEntity.present) {
+      map['related_entity'] = Variable<String>(relatedEntity.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('FirstRelatedEntitiesCompanion(')
+          ..write('shouldSync: $shouldSync, ')
+          ..write('uuid: $uuid, ')
+          ..write('id: $id, ')
+          ..write('relatedEntity: $relatedEntity')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $FirstRelatedEntitiesTable extends FirstRelatedEntities
+    with TableInfo<$FirstRelatedEntitiesTable, FirstRelatedEntity> {
+  final GeneratedDatabase _db;
+  final String? _alias;
+  $FirstRelatedEntitiesTable(this._db, [this._alias]);
+  final VerificationMeta _shouldSyncMeta = const VerificationMeta('shouldSync');
+  @override
+  late final GeneratedBoolColumn shouldSync = _constructShouldSync();
+  GeneratedBoolColumn _constructShouldSync() {
+    return GeneratedBoolColumn(
+      'should_sync',
+      $tableName,
+      false,
+    )..clientDefault = () => true;
+  }
+
+  final VerificationMeta _uuidMeta = const VerificationMeta('uuid');
+  @override
+  late final GeneratedTextColumn uuid = _constructUuid();
+  GeneratedTextColumn _constructUuid() {
+    return GeneratedTextColumn(
+      'uuid',
+      $tableName,
+      false,
+    );
+  }
+
+  final VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedIntColumn id = _constructId();
+  GeneratedIntColumn _constructId() {
+    return GeneratedIntColumn('id', $tableName, false,
+        hasAutoIncrement: true, declaredAsPrimaryKey: true);
+  }
+
+  final VerificationMeta _relatedEntityMeta =
+      const VerificationMeta('relatedEntity');
+  @override
+  late final GeneratedTextColumn relatedEntity = _constructRelatedEntity();
+  GeneratedTextColumn _constructRelatedEntity() {
+    return GeneratedTextColumn(
+      'related_entity',
+      $tableName,
+      false,
+    );
+  }
+
+  @override
+  List<GeneratedColumn> get $columns => [shouldSync, uuid, id, relatedEntity];
+  @override
+  $FirstRelatedEntitiesTable get asDslTable => this;
+  @override
+  String get $tableName => _alias ?? 'first_related_entities';
+  @override
+  final String actualTableName = 'first_related_entities';
+  @override
+  VerificationContext validateIntegrity(Insertable<FirstRelatedEntity> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('should_sync')) {
+      context.handle(
+          _shouldSyncMeta,
+          shouldSync.isAcceptableOrUnknown(
+              data['should_sync']!, _shouldSyncMeta));
+    }
+    if (data.containsKey('uuid')) {
+      context.handle(
+          _uuidMeta, uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta));
+    } else if (isInserting) {
+      context.missing(_uuidMeta);
+    }
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('related_entity')) {
+      context.handle(
+          _relatedEntityMeta,
+          relatedEntity.isAcceptableOrUnknown(
+              data['related_entity']!, _relatedEntityMeta));
+    } else if (isInserting) {
+      context.missing(_relatedEntityMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  FirstRelatedEntity map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : null;
+    return FirstRelatedEntity.fromData(data, _db, prefix: effectivePrefix);
+  }
+
+  @override
+  $FirstRelatedEntitiesTable createAlias(String alias) {
+    return $FirstRelatedEntitiesTable(_db, alias);
+  }
+}
+
+class SecondRelatedEntity extends DataClass
+    implements Insertable<SecondRelatedEntity> {
+  /// Indicates if the entity should be synced
+  final bool shouldSync;
+  final String uuid;
+  final int id;
+  SecondRelatedEntity(
+      {required this.shouldSync, required this.uuid, required this.id});
+  factory SecondRelatedEntity.fromData(
+      Map<String, dynamic> data, GeneratedDatabase db,
+      {String? prefix}) {
+    final effectivePrefix = prefix ?? '';
+    final boolType = db.typeSystem.forDartType<bool>();
+    final stringType = db.typeSystem.forDartType<String>();
+    final intType = db.typeSystem.forDartType<int>();
+    return SecondRelatedEntity(
+      shouldSync: boolType
+          .mapFromDatabaseResponse(data['${effectivePrefix}should_sync'])!,
+      uuid: stringType.mapFromDatabaseResponse(data['${effectivePrefix}uuid'])!,
+      id: intType.mapFromDatabaseResponse(data['${effectivePrefix}id'])!,
+    );
+  }
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['should_sync'] = Variable<bool>(shouldSync);
+    map['uuid'] = Variable<String>(uuid);
+    map['id'] = Variable<int>(id);
+    return map;
+  }
+
+  SecondRelatedEntitiesCompanion toCompanion(bool nullToAbsent) {
+    return SecondRelatedEntitiesCompanion(
+      shouldSync: Value(shouldSync),
+      uuid: Value(uuid),
+      id: Value(id),
+    );
+  }
+
+  factory SecondRelatedEntity.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= moorRuntimeOptions.defaultSerializer;
+    return SecondRelatedEntity(
+      shouldSync: serializer.fromJson<bool>(json['shouldSync']),
+      uuid: serializer.fromJson<String>(json['uuid']),
+      id: serializer.fromJson<int>(json['id']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= moorRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'shouldSync': serializer.toJson<bool>(shouldSync),
+      'uuid': serializer.toJson<String>(uuid),
+      'id': serializer.toJson<int>(id),
+    };
+  }
+
+  SecondRelatedEntity copyWith({bool? shouldSync, String? uuid, int? id}) =>
+      SecondRelatedEntity(
+        shouldSync: shouldSync ?? this.shouldSync,
+        uuid: uuid ?? this.uuid,
+        id: id ?? this.id,
+      );
+  @override
+  String toString() {
+    return (StringBuffer('SecondRelatedEntity(')
+          ..write('shouldSync: $shouldSync, ')
+          ..write('uuid: $uuid, ')
+          ..write('id: $id')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode =>
+      $mrjf($mrjc(shouldSync.hashCode, $mrjc(uuid.hashCode, id.hashCode)));
+  @override
+  bool operator ==(dynamic other) =>
+      identical(this, other) ||
+      (other is SecondRelatedEntity &&
+          other.shouldSync == this.shouldSync &&
+          other.uuid == this.uuid &&
+          other.id == this.id);
+}
+
+class SecondRelatedEntitiesCompanion
+    extends UpdateCompanion<SecondRelatedEntity> {
+  final Value<bool> shouldSync;
+  final Value<String> uuid;
+  final Value<int> id;
+  const SecondRelatedEntitiesCompanion({
+    this.shouldSync = const Value.absent(),
+    this.uuid = const Value.absent(),
+    this.id = const Value.absent(),
+  });
+  SecondRelatedEntitiesCompanion.insert({
+    this.shouldSync = const Value.absent(),
+    required String uuid,
+    this.id = const Value.absent(),
+  }) : uuid = Value(uuid);
+  static Insertable<SecondRelatedEntity> custom({
+    Expression<bool>? shouldSync,
+    Expression<String>? uuid,
+    Expression<int>? id,
+  }) {
+    return RawValuesInsertable({
+      if (shouldSync != null) 'should_sync': shouldSync,
+      if (uuid != null) 'uuid': uuid,
+      if (id != null) 'id': id,
+    });
+  }
+
+  SecondRelatedEntitiesCompanion copyWith(
+      {Value<bool>? shouldSync, Value<String>? uuid, Value<int>? id}) {
+    return SecondRelatedEntitiesCompanion(
+      shouldSync: shouldSync ?? this.shouldSync,
+      uuid: uuid ?? this.uuid,
+      id: id ?? this.id,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (shouldSync.present) {
+      map['should_sync'] = Variable<bool>(shouldSync.value);
+    }
+    if (uuid.present) {
+      map['uuid'] = Variable<String>(uuid.value);
+    }
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SecondRelatedEntitiesCompanion(')
+          ..write('shouldSync: $shouldSync, ')
+          ..write('uuid: $uuid, ')
+          ..write('id: $id')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $SecondRelatedEntitiesTable extends SecondRelatedEntities
+    with TableInfo<$SecondRelatedEntitiesTable, SecondRelatedEntity> {
+  final GeneratedDatabase _db;
+  final String? _alias;
+  $SecondRelatedEntitiesTable(this._db, [this._alias]);
+  final VerificationMeta _shouldSyncMeta = const VerificationMeta('shouldSync');
+  @override
+  late final GeneratedBoolColumn shouldSync = _constructShouldSync();
+  GeneratedBoolColumn _constructShouldSync() {
+    return GeneratedBoolColumn(
+      'should_sync',
+      $tableName,
+      false,
+    )..clientDefault = () => true;
+  }
+
+  final VerificationMeta _uuidMeta = const VerificationMeta('uuid');
+  @override
+  late final GeneratedTextColumn uuid = _constructUuid();
+  GeneratedTextColumn _constructUuid() {
+    return GeneratedTextColumn(
+      'uuid',
+      $tableName,
+      false,
+    );
+  }
+
+  final VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedIntColumn id = _constructId();
+  GeneratedIntColumn _constructId() {
+    return GeneratedIntColumn('id', $tableName, false,
+        hasAutoIncrement: true, declaredAsPrimaryKey: true);
+  }
+
+  @override
+  List<GeneratedColumn> get $columns => [shouldSync, uuid, id];
+  @override
+  $SecondRelatedEntitiesTable get asDslTable => this;
+  @override
+  String get $tableName => _alias ?? 'second_related_entities';
+  @override
+  final String actualTableName = 'second_related_entities';
+  @override
+  VerificationContext validateIntegrity(
+      Insertable<SecondRelatedEntity> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('should_sync')) {
+      context.handle(
+          _shouldSyncMeta,
+          shouldSync.isAcceptableOrUnknown(
+              data['should_sync']!, _shouldSyncMeta));
+    }
+    if (data.containsKey('uuid')) {
+      context.handle(
+          _uuidMeta, uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta));
+    } else if (isInserting) {
+      context.missing(_uuidMeta);
+    }
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  SecondRelatedEntity map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : null;
+    return SecondRelatedEntity.fromData(data, _db, prefix: effectivePrefix);
+  }
+
+  @override
+  $SecondRelatedEntitiesTable createAlias(String alias) {
+    return $SecondRelatedEntitiesTable(_db, alias);
+  }
+}
+
 abstract class _$TestDatabase extends GeneratedDatabase {
   _$TestDatabase(QueryExecutor e) : super(SqlTypeSystem.defaultInstance, e);
   late final $TestMoorEntitiesTable testMoorEntities =
       $TestMoorEntitiesTable(this);
+  late final $FirstRelatedEntitiesTable firstRelatedEntities =
+      $FirstRelatedEntitiesTable(this);
+  late final $SecondRelatedEntitiesTable secondRelatedEntities =
+      $SecondRelatedEntitiesTable(this);
   @override
   Iterable<TableInfo> get allTables => allSchemaEntities.whereType<TableInfo>();
   @override
-  List<DatabaseSchemaEntity> get allSchemaEntities => [testMoorEntities];
+  List<DatabaseSchemaEntity> get allSchemaEntities =>
+      [testMoorEntities, firstRelatedEntities, secondRelatedEntities];
 }

--- a/test/models/related_entities.dart
+++ b/test/models/related_entities.dart
@@ -1,0 +1,66 @@
+import 'package:entity_sync/entity_sync.dart';
+import 'package:entity_sync/moor_sync.dart';
+import 'package:moor/moor.dart';
+
+import 'database.dart';
+
+part 'related_entities.g.dart';
+
+@DataClassName('FirstRelatedEntity')
+class FirstRelatedEntities extends SyncableTable {
+  TextColumn get uuid => text()();
+
+  IntColumn get id => integer().autoIncrement()();
+
+  TextColumn get relatedEntity => text()();
+
+  @override
+  SyncableTable actualTable() => this;
+
+  @override
+  Column localKeyColumn() => id;
+
+  @override
+  Column remoteKeyColumn() => uuid;
+}
+
+@DataClassName('SecondRelatedEntity')
+class SecondRelatedEntities extends SyncableTable {
+  TextColumn get uuid => text()();
+
+  IntColumn get id => integer().autoIncrement()();
+
+  @override
+  SyncableTable actualTable() => this;
+
+  @override
+  Column localKeyColumn() => id;
+
+  @override
+  Column remoteKeyColumn() => uuid;
+}
+
+@UseEntitySync(
+  FirstRelatedEntity,
+  fields: [
+    StringField('uuid'),
+    IntegerField('id'),
+    StringField('relatedEntity'),
+  ],
+  remoteKeyField: StringField('uuid'),
+  keyField: IntegerField('id'),
+  flagField: BoolField('shouldSync'),
+)
+class FirstRelatedEntitySync extends $_FirstRelatedEntitySync {}
+
+@UseEntitySync(
+  SecondRelatedEntity,
+  fields: [
+    StringField('uuid'),
+    IntegerField('id'),
+  ],
+  remoteKeyField: StringField('uuid'),
+  keyField: IntegerField('id'),
+  flagField: BoolField('shouldSync'),
+)
+class SecondRelatedEntitySync extends $_SecondRelatedEntitySync {}

--- a/test/models/related_entities.g.dart
+++ b/test/models/related_entities.g.dart
@@ -1,0 +1,211 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'related_entities.dart';
+
+// **************************************************************************
+// UseEntitySyncGenerator
+// **************************************************************************
+
+// ignore_for_file: non_constant_identifier_names
+class FirstRelatedEntityProxy extends FirstRelatedEntity
+    with ProxyMixin<FirstRelatedEntity>, SyncableMixin, SerializableMixin {
+  FirstRelatedEntityProxy({
+    required bool shouldSync,
+    required String uuid,
+    required int id,
+    required String relatedEntity,
+  }) : super(
+          shouldSync: shouldSync,
+          uuid: uuid,
+          id: id,
+          relatedEntity: relatedEntity,
+        );
+  @override
+  Map<String, dynamic> toMap() {
+    return {
+      'shouldSync': shouldSync,
+      'uuid': uuid,
+      'id': id,
+      'relatedEntity': relatedEntity,
+    };
+  }
+
+  @override
+  FirstRelatedEntityProxy copyFromMap(Map<String, dynamic> data) {
+    return FirstRelatedEntityProxy(
+      shouldSync: data['shouldSync'],
+      uuid: data['uuid'],
+      id: data['id'],
+      relatedEntity: data['relatedEntity'],
+    );
+  }
+
+  @override
+  final keyField = IntegerField('id', source: 'id');
+
+  @override
+  final remoteKeyField = StringField('uuid', source: 'uuid');
+
+  @override
+  final flagField = BoolField('shouldSync', source: 'shouldSync');
+
+  FirstRelatedEntityProxy.fromEntity(FirstRelatedEntity instance)
+      : super(
+          shouldSync: instance.shouldSync,
+          uuid: instance.uuid,
+          id: instance.id,
+          relatedEntity: instance.relatedEntity,
+        );
+}
+
+class BaseFirstRelatedEntitySerializer
+    extends Serializer<FirstRelatedEntityProxy> {
+  BaseFirstRelatedEntitySerializer(
+      {Map<String, dynamic>? data,
+      FirstRelatedEntityProxy? instance,
+      String prefix = ''})
+      : super(data: data, instance: instance, prefix: prefix);
+
+  @override
+  final fields = [
+    StringField('uuid', source: 'uuid'),
+    IntegerField('id', source: 'id'),
+    StringField('relatedEntity', source: 'relatedEntity'),
+  ];
+  String? validateUuid(String? value) {
+    return value;
+  }
+
+  int? validateId(int? value) {
+    return value;
+  }
+
+  String? validateRelatedEntity(String? value) {
+    return value;
+  }
+
+  @override
+  Map toMap() {
+    return {
+      'validateUuid': validateUuid,
+      'validateId': validateId,
+      'validateRelatedEntity': validateRelatedEntity,
+    };
+  }
+
+  @override
+  FirstRelatedEntityProxy createInstance(Map<String, dynamic> data) {
+    return FirstRelatedEntityProxy(
+      uuid: data['uuid'],
+      id: data['id'],
+      relatedEntity: data['relatedEntity'],
+      shouldSync: false,
+    );
+  }
+}
+
+class FirstRelatedEntityProxyFactory
+    extends ProxyFactory<FirstRelatedEntityProxy, FirstRelatedEntity> {
+  @override
+  FirstRelatedEntityProxy fromInstance(FirstRelatedEntity instance) {
+    return FirstRelatedEntityProxy.fromEntity(instance);
+  }
+}
+
+class $_FirstRelatedEntitySync {}
+
+// ignore_for_file: non_constant_identifier_names
+class SecondRelatedEntityProxy extends SecondRelatedEntity
+    with ProxyMixin<SecondRelatedEntity>, SyncableMixin, SerializableMixin {
+  SecondRelatedEntityProxy({
+    required bool shouldSync,
+    required String uuid,
+    required int id,
+  }) : super(
+          shouldSync: shouldSync,
+          uuid: uuid,
+          id: id,
+        );
+  @override
+  Map<String, dynamic> toMap() {
+    return {
+      'shouldSync': shouldSync,
+      'uuid': uuid,
+      'id': id,
+    };
+  }
+
+  @override
+  SecondRelatedEntityProxy copyFromMap(Map<String, dynamic> data) {
+    return SecondRelatedEntityProxy(
+      shouldSync: data['shouldSync'],
+      uuid: data['uuid'],
+      id: data['id'],
+    );
+  }
+
+  @override
+  final keyField = IntegerField('id', source: 'id');
+
+  @override
+  final remoteKeyField = StringField('uuid', source: 'uuid');
+
+  @override
+  final flagField = BoolField('shouldSync', source: 'shouldSync');
+
+  SecondRelatedEntityProxy.fromEntity(SecondRelatedEntity instance)
+      : super(
+          shouldSync: instance.shouldSync,
+          uuid: instance.uuid,
+          id: instance.id,
+        );
+}
+
+class BaseSecondRelatedEntitySerializer
+    extends Serializer<SecondRelatedEntityProxy> {
+  BaseSecondRelatedEntitySerializer(
+      {Map<String, dynamic>? data,
+      SecondRelatedEntityProxy? instance,
+      String prefix = ''})
+      : super(data: data, instance: instance, prefix: prefix);
+
+  @override
+  final fields = [
+    StringField('uuid', source: 'uuid'),
+    IntegerField('id', source: 'id'),
+  ];
+  String? validateUuid(String? value) {
+    return value;
+  }
+
+  int? validateId(int? value) {
+    return value;
+  }
+
+  @override
+  Map toMap() {
+    return {
+      'validateUuid': validateUuid,
+      'validateId': validateId,
+    };
+  }
+
+  @override
+  SecondRelatedEntityProxy createInstance(Map<String, dynamic> data) {
+    return SecondRelatedEntityProxy(
+      uuid: data['uuid'],
+      id: data['id'],
+      shouldSync: false,
+    );
+  }
+}
+
+class SecondRelatedEntityProxyFactory
+    extends ProxyFactory<SecondRelatedEntityProxy, SecondRelatedEntity> {
+  @override
+  SecondRelatedEntityProxy fromInstance(SecondRelatedEntity instance) {
+    return SecondRelatedEntityProxy.fromEntity(instance);
+  }
+}
+
+class $_SecondRelatedEntitySync {}

--- a/test/moor_test.dart
+++ b/test/moor_test.dart
@@ -87,7 +87,9 @@ void main() {
 }
 
 Future<SyncResult> localOutdatedDataSync(
-    TestDatabase database, bool readOnlyEndpoint) async {
+  TestDatabase database,
+  bool readOnlyEndpoint,
+) async {
   /// Set up the mock client
   final url = 'https://www.example.com/test-entity/';
   final client = MockClient();

--- a/test/related_syncing_test.dart
+++ b/test/related_syncing_test.dart
@@ -1,0 +1,106 @@
+import 'dart:convert';
+
+import 'package:entity_sync/entity_sync.dart';
+import 'package:entity_sync/moor_sync.dart';
+import 'package:mockito/mockito.dart';
+import 'package:moor/ffi.dart';
+import 'package:test/test.dart';
+import 'package:http/http.dart' as http;
+
+import 'endpoints_test.mocks.dart';
+import 'models/database.dart';
+import 'models/related_entities.dart';
+
+void main() {
+  late TestDatabase database;
+  late MockClient client;
+
+  final firstRelatedUrl = 'https://www.example.com/first-related-entity/';
+  final secondRelatedUrl = 'https://www.example.com/second-related-entity/';
+
+  group('Test SyncController.sync with related entities', () {
+    setUp(() {
+      database = TestDatabase(VmDatabase.memory());
+      client = MockClient();
+
+      final statusCode = 200;
+
+      final secondRelatedResponseBody1 = json.encode({
+        'id': 1,
+        'uuid': '1',
+      });
+      final secondRelatedResponseBody2 = json.encode({
+        'id': 2,
+        'uuid': '2',
+      });
+      when(client.get(Uri.parse('${secondRelatedUrl}1'), headers: {}))
+          .thenAnswer(
+        (a) async => http.Response(
+          secondRelatedResponseBody1,
+          statusCode,
+        ),
+      );
+      when(client.get(Uri.parse('${secondRelatedUrl}2'), headers: {}))
+          .thenAnswer(
+        (a) async => http.Response(
+          secondRelatedResponseBody2,
+          statusCode,
+        ),
+      );
+
+      final firstRelatedResponseBody = json.encode([
+        {'id': 1, 'uuid': '1', 'relatedEntity': '1'},
+        {'id': 2, 'uuid': '2', 'relatedEntity': '2'}
+      ]);
+      when(client.get(Uri.parse(firstRelatedUrl), headers: {})).thenAnswer(
+        (realInvocation) async => http.Response(
+          firstRelatedResponseBody,
+          statusCode,
+        ),
+      );
+    });
+
+    test(
+      'Test pulling remote data case with empty related entities',
+      () async {
+        final endpoint = RestfulApiEndpoint<FirstRelatedEntityProxy>(
+            firstRelatedUrl, BaseFirstRelatedEntitySerializer(),
+            client: client, readOnly: true, headers: {});
+        final factory = FirstRelatedEntityProxyFactory();
+        final storage = MoorStorage<FirstRelatedEntityProxy>(
+          database.firstRelatedEntities,
+          database,
+          factory,
+        );
+
+        final secondEndpoint = RestfulApiEndpoint<SecondRelatedEntityProxy>(
+            secondRelatedUrl, BaseSecondRelatedEntitySerializer(),
+            client: client, readOnly: true, headers: {});
+        final secondFactory = SecondRelatedEntityProxyFactory();
+        final secondStorage = MoorStorage<SecondRelatedEntityProxy>(
+          database.secondRelatedEntities,
+          database,
+          secondFactory,
+        );
+
+        final firstRelation = MoorRelation(
+          database,
+          'relatedEntity',
+          database.secondRelatedEntities,
+        );
+        final syncController = SyncController<FirstRelatedEntityProxy>(
+          endpoint,
+          storage,
+          relations: [
+            SyncControllerRelation(firstRelation, secondEndpoint, secondStorage)
+          ],
+        );
+        await syncController.sync();
+
+        final secondRelatedEntities =
+            await database.select(database.secondRelatedEntities).get();
+        expect(secondRelatedEntities.length, 2);
+      },
+    );
+  });
+}

--- a/test/related_syncing_test.dart
+++ b/test/related_syncing_test.dart
@@ -84,9 +84,9 @@ void main() {
         );
 
         final firstRelation = MoorRelation(
-          database,
-          'relatedEntity',
-          database.secondRelatedEntities,
+          database: database,
+          fkColumn: 'relatedEntity',
+          fkTable: database.secondRelatedEntities,
         );
         final syncController = SyncController<FirstRelatedEntityProxy>(
           endpoint,


### PR DESCRIPTION
The solution I've developed is quick and simple. I've looked into using `OPTION` and I think it's much more complicated and required a lot more time.

## Summary

Let the original model be `A`.
Let the related model be `B`.

In the process of syncing `A`, if there is a new value for the FK, we will sync `B` with respect to FK. That is, the `URL` to sync related entity is, for example, `/related-entity/fk`.

## Design process
To get a new entity of `B` from `A`,  `A` needs to know about:
- B's endpoint.
- B's storage.
- If need to sync the instance in `B` or not based on if `A` has a new instance or an instance of `A` has been changed.

The only class that knows about all those information is the `SyncController` class. Hence I created a new class `SyncControllerRelation` that defines a relationship between the SyncControllers and provides all the information that the SyncController needs to sync its related entity.

In addition to that, a class `Relation` is created to define the relationship between syncable entities that will be fed into the `SyncControllerRelation` class.

## About using `OPTIONS` method
I was looking into it earlier but there are some differences between the fields in `OPTIONS` and our models. The question is then which is which. After how do we need to assign the related model returned from `OPTIONS` to its storage and its endpoint.

`OPTIONS` is also needed to be called in a separate request. Do we call it every request to know if there are related models?  Or, do we call it before the run time? 

## Logging
The logs should be more descriptive now. Just a simple log on the result of `SyncController.sync`, we would get an output of: 
```dart
SyncResult(pushResults: [], pullResults: EndpointResult(instances: [FirstRelatedEntity(shouldSync: false, uuid: 1, id: 1, relatedEntity: 1), FirstRelatedEntity(shouldSync: false, uuid: 2, id: 2, relatedEntity: 2)], errors: [], responseBody: [{"id":1,"uuid":"1","relatedEntity":"1"},{"id":2,"uuid":"2","relatedEntity":"2"}], responseCode: 200))
```

Before on Sentry it was:
```dart
Instance of 'SyncResult'
Instance of 'Response'
```